### PR TITLE
Add python features

### DIFF
--- a/grammars/enaml.cson
+++ b/grammars/enaml.cson
@@ -384,4 +384,4 @@ patterns: [
     include: "source.python"
   }
 ]
-scopeName: "source.enaml"
+scopeName: "source.python.enaml"

--- a/settings/language-enaml.cson
+++ b/settings/language-enaml.cson
@@ -1,0 +1,8 @@
+'.source.enaml':
+  'editor':
+    'autoIndentOnPaste': false
+    'softTabs': true
+    'tabLength': 4
+    'commentStart': '# '
+    'increaseIndentPattern': '^\\s*\\w*\\b.*:\\s*$'
+    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'


### PR DESCRIPTION
Hi there!

I'd been looking for an enaml specification for Atom for quite some time and finally frankensteined together my own. Yours looks much more solid though.

So I only have two things to add:
- include enaml in the python scope, this way autocompletion and the logical operators (and, or, ...) work well
- editor settings for autoindent, and comment by shortcut